### PR TITLE
ENH add run-on-sim flag for running on image simulation catalogs

### DIFF
--- a/bin/pizza-patches-make-cut-files
+++ b/bin/pizza-patches-make-cut-files
@@ -161,6 +161,8 @@ def read_catalog(*, fname, uid_info, cuts_version, patches, keep_coarse_cuts, ru
         The array mapping pizza slices to patch IDs.
     keep_coarse_cuts : bool
         If True, return the data after the coarse cuts and set mdet_flags to the fine cuts.
+    run_on_sim : bool
+        If True, zero out the mdet flags bit at 16 (MASK_TILEDUPE) and set patch_num to -1
 
     Returns
     -------

--- a/bin/pizza-patches-make-cut-files
+++ b/bin/pizza-patches-make-cut-files
@@ -21,26 +21,19 @@ def get_args():
         help='file holding metadetect output files',
         required=True,
     )
-    # parser.add_argument(
-    #     '--patches',
-    #     help='pizza cutter patches file',
-    #     required=True,
-    # )
     parser.add_argument(
         '--uid-info',
         help='file holding uid info',
         required=True,
     )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--patches', help='pizza cutter patches file')
+    group.add_argument('--run-on-sim', action='store_true', help='run on simulated tiles')
     parser.add_argument(
         '--outdir',
         help='output dir, will be created',
         required=True,
     )
-
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--patches', help='pizza cutter patches file')
-    group.add_argument('--run-on-sim', action='store_true', help='run on simulated tiles')
-
     parser.add_argument(
         '--keep-coarse-cuts',
         help='keep all objects that pass coarse cuts',

--- a/bin/pizza-patches-make-cut-files
+++ b/bin/pizza-patches-make-cut-files
@@ -174,34 +174,20 @@ def read_catalog(*, fname, uid_info, cuts_version, patches, keep_coarse_cuts, ru
     print('    making initial cuts', flush=True)
     if run_on_sim:
         orig_data["mask_flags"] = orig_data["mask_flags"] & (~16)
-        inds, = np.where(
-            (orig_data['psfrec_flags'] == 0) &
-            (orig_data['gauss_flags'] == 0) &
-            (orig_data['gauss_s2n'] > 5) &
-            (orig_data['pgauss_T_flags'] == 0) &
-            (orig_data['pgauss_s2n'] > 5) &
-            (orig_data['pgauss_band_flux_flags_g'] == 0) &
-            (orig_data['pgauss_band_flux_flags_r'] == 0) &
-            (orig_data['pgauss_band_flux_flags_i'] == 0) &
-            (orig_data['pgauss_band_flux_flags_z'] == 0) &
-            (orig_data['shear_bands'] == '123')
-        )
-        orig_data = orig_data[inds]
-    else:
-        inds, = np.where(
-            (orig_data['psfrec_flags'] == 0) &
-            (orig_data['gauss_flags'] == 0) &
-            (orig_data['gauss_s2n'] > 5) &
-            (orig_data['pgauss_T_flags'] == 0) &
-            (orig_data['pgauss_s2n'] > 5) &
-            (orig_data['pgauss_band_flux_flags_g'] == 0) &
-            (orig_data['pgauss_band_flux_flags_r'] == 0) &
-            (orig_data['pgauss_band_flux_flags_i'] == 0) &
-            (orig_data['pgauss_band_flux_flags_z'] == 0) &
-            (orig_data['mask_flags'] == 0) &
-            (orig_data['shear_bands'] == '123')
-        )
-        orig_data = orig_data[inds]
+    inds, = np.where(
+        (orig_data['psfrec_flags'] == 0) &
+        (orig_data['gauss_flags'] == 0) &
+        (orig_data['gauss_s2n'] > 5) &
+        (orig_data['pgauss_T_flags'] == 0) &
+        (orig_data['pgauss_s2n'] > 5) &
+        (orig_data['pgauss_band_flux_flags_g'] == 0) &
+        (orig_data['pgauss_band_flux_flags_r'] == 0) &
+        (orig_data['pgauss_band_flux_flags_i'] == 0) &
+        (orig_data['pgauss_band_flux_flags_z'] == 0) &
+        (orig_data['mask_flags'] == 0) &
+        (orig_data['shear_bands'] == '123')
+    )
+    orig_data = orig_data[inds]
 
     print('    applying mag deredenning', flush=True)
     orig_data = add_extinction_correction_columns(orig_data)

--- a/bin/pizza-patches-make-cut-files
+++ b/bin/pizza-patches-make-cut-files
@@ -21,11 +21,11 @@ def get_args():
         help='file holding metadetect output files',
         required=True,
     )
-    parser.add_argument(
-        '--patches',
-        help='pizza cutter patches file',
-        required=True,
-    )
+    # parser.add_argument(
+    #     '--patches',
+    #     help='pizza cutter patches file',
+    #     required=True,
+    # )
     parser.add_argument(
         '--uid-info',
         help='file holding uid info',
@@ -36,6 +36,11 @@ def get_args():
         help='output dir, will be created',
         required=True,
     )
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--patches', help='pizza cutter patches file')
+    group.add_argument('--run-on-sim', action='store_true', help='run on simulated tiles')
+
     parser.add_argument(
         '--keep-coarse-cuts',
         help='keep all objects that pass coarse cuts',
@@ -136,7 +141,7 @@ def get_output_dtype():
     ]
 
 
-def read_catalog(*, fname, uid_info, cuts_version, patches, keep_coarse_cuts):
+def read_catalog(*, fname, uid_info, cuts_version, patches, keep_coarse_cuts, run_on_sim):
     """Read the catalog, make cuts, and add uid+patch_num fields.
 
     Some data types what are not used for precise aggregates are down converted
@@ -167,20 +172,36 @@ def read_catalog(*, fname, uid_info, cuts_version, patches, keep_coarse_cuts):
 
     # not all of these are in output
     print('    making initial cuts', flush=True)
-    inds, = np.where(
-        (orig_data['psfrec_flags'] == 0) &
-        (orig_data['gauss_flags'] == 0) &
-        (orig_data['gauss_s2n'] > 5) &
-        (orig_data['pgauss_T_flags'] == 0) &
-        (orig_data['pgauss_s2n'] > 5) &
-        (orig_data['pgauss_band_flux_flags_g'] == 0) &
-        (orig_data['pgauss_band_flux_flags_r'] == 0) &
-        (orig_data['pgauss_band_flux_flags_i'] == 0) &
-        (orig_data['pgauss_band_flux_flags_z'] == 0) &
-        (orig_data['mask_flags'] == 0) &
-        (orig_data['shear_bands'] == '123')
-    )
-    orig_data = orig_data[inds]
+    if run_on_sim:
+        orig_data["mask_flags"] = orig_data["mask_flags"] & (~16)
+        inds, = np.where(
+            (orig_data['psfrec_flags'] == 0) &
+            (orig_data['gauss_flags'] == 0) &
+            (orig_data['gauss_s2n'] > 5) &
+            (orig_data['pgauss_T_flags'] == 0) &
+            (orig_data['pgauss_s2n'] > 5) &
+            (orig_data['pgauss_band_flux_flags_g'] == 0) &
+            (orig_data['pgauss_band_flux_flags_r'] == 0) &
+            (orig_data['pgauss_band_flux_flags_i'] == 0) &
+            (orig_data['pgauss_band_flux_flags_z'] == 0) &
+            (orig_data['shear_bands'] == '123')
+        )
+        orig_data = orig_data[inds]
+    else:
+        inds, = np.where(
+            (orig_data['psfrec_flags'] == 0) &
+            (orig_data['gauss_flags'] == 0) &
+            (orig_data['gauss_s2n'] > 5) &
+            (orig_data['pgauss_T_flags'] == 0) &
+            (orig_data['pgauss_s2n'] > 5) &
+            (orig_data['pgauss_band_flux_flags_g'] == 0) &
+            (orig_data['pgauss_band_flux_flags_r'] == 0) &
+            (orig_data['pgauss_band_flux_flags_i'] == 0) &
+            (orig_data['pgauss_band_flux_flags_z'] == 0) &
+            (orig_data['mask_flags'] == 0) &
+            (orig_data['shear_bands'] == '123')
+        )
+        orig_data = orig_data[inds]
 
     print('    applying mag deredenning', flush=True)
     orig_data = add_extinction_correction_columns(orig_data)
@@ -202,12 +223,15 @@ def read_catalog(*, fname, uid_info, cuts_version, patches, keep_coarse_cuts):
     )
 
     print('    matching to get patch numbers', flush=True)
-    mpatches, mdata = match_ids(
-        arr1=patches['pizza_id'],
-        arr2=pizza_ids,
-    )
-    assert mdata.size == data.size
-    data['patch_num'] = patches['patch_num'][mpatches]
+    if run_on_sim:
+        data['patch_num'] = -1
+    else:
+        mpatches, mdata = match_ids(
+            arr1=patches['pizza_id'],
+            arr2=pizza_ids,
+        )
+        assert mdata.size == data.size
+        data['patch_num'] = patches['patch_num'][mpatches]
 
 
     if keep_coarse_cuts:
@@ -235,6 +259,7 @@ def _run_file(
     clobber,
     outdir,
     keep_coarse_cuts,
+    run_on_sim,
 ):
     oname = os.path.join(outdir, os.path.basename(fname))
 
@@ -254,6 +279,7 @@ def _run_file(
         cuts_version="6",
         patches=patches,
         keep_coarse_cuts=keep_coarse_cuts,
+        run_on_sim=run_on_sim,
     )
 
     print('    writing', flush=True)
@@ -284,6 +310,7 @@ def _run_files(
     parallel,
     outdir,
     keep_coarse_cuts,
+    run_on_sim,
 ):
     if not parallel:
         if isinstance(uid_info, str):
@@ -306,6 +333,7 @@ def _run_files(
                 clobber=clobber,
                 outdir=outdir,
                 keep_coarse_cuts=keep_coarse_cuts,
+                run_on_sim=run_on_sim,
             )
             ntot += _ntot
             nfinal += _nfinal
@@ -326,6 +354,7 @@ def _run_files(
                         clobber=clobber,
                         outdir=outdir,
                         keep_coarse_cuts=keep_coarse_cuts,
+                        run_on_sim=run_on_sim,
                     )
                 )
 
@@ -360,6 +389,7 @@ def main(args):
             clobber=args.clobber,
             outdir=args.outdir,
             keep_coarse_cuts=args.keep_coarse_cuts,
+            run_on_sim=args.run_on_sim,
         )
     else:
         _run_files(
@@ -369,6 +399,7 @@ def main(args):
             clobber=args.clobber,
             outdir=args.outdir,
             keep_coarse_cuts=args.keep_coarse_cuts,
+            run_on_sim=args.run_on_sim,
             parallel=args.parallel,
         )
 


### PR DESCRIPTION
This PR adds an option to `pizza-patches-make-cut-files` for running on image sims. Specifically, we add `--run-on-sim` as a mutually exclusive flag with `--patches`. This will set the mask bits appropriately for the imsims (where tiles are simulated in isolation and therefore do not overlap) and also set the `patch_num` to -1 for all simulated data.